### PR TITLE
Fix bug in casual-lib--quit-one-suffix-label

### DIFF
--- a/lisp/casual-lib.el
+++ b/lisp/casual-lib.el
@@ -139,7 +139,7 @@ V is either nil or non-nil."
   :transient nil
   :key "C-g"
   :if-not #'casual-lib-hide-navigation-p
-  :description (casual-lib--quit-one-suffix-label)
+  :description #'casual-lib--quit-one-suffix-label
   (interactive)
   (transient-quit-one))
 


### PR DESCRIPTION
- This fixes a bug where the description for casual-lib-quit-one is not rendered
correctly. Bug was surfaced with recent Transient 0.7.3 release.
