### PR TITLE
Merge development to main 20240716_132000

### DIFF
--- a/lisp/casual-lib-version.el
+++ b/lisp/casual-lib-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-lib-version "1.1.0"
+(defconst casual-lib-version "1.1.1"
   "Casual Lib Version.")
 
 (defun casual-lib-version ()

--- a/lisp/casual-lib.el
+++ b/lisp/casual-lib.el
@@ -139,7 +139,7 @@ V is either nil or non-nil."
   :transient nil
   :key "C-g"
   :if-not #'casual-lib-hide-navigation-p
-  :description (casual-lib--quit-one-suffix-label)
+  :description #'casual-lib--quit-one-suffix-label
   (interactive)
   (transient-quit-one))
 

--- a/lisp/casual-lib.el
+++ b/lisp/casual-lib.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-lib
 ;; Keywords: tools
-;; Version: 1.1.0
+;; Version: 1.1.1
 ;; Package-Requires: ((emacs "29.1") (transient "0.6.0"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Fix bug in casual-lib--quit-one-suffix-label**
  - This fixes a bug where the description for casual-lib-quit-one is not rendered
  correctly. Bug was surfaced with recent Transient 0.7.3 release.
  

- **Bump version to 1.1.1**
  