### PR TITLE
Add mock support

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,7 @@
 [[https://melpa.org/#/casual-lib][file:https://melpa.org/packages/casual-lib-badge.svg]]
+
 * Casual Lib
-Casual Lib is a library package used to support the Casual porcelains. 
+Casual Lib is a library package used to support the Casual suite of user interfaces. 
 
 * Requirements
 Casual Lib requires Emacs 29.3+ and Transient 0.6.0+.

--- a/docs/developer.org
+++ b/docs/developer.org
@@ -15,11 +15,7 @@ Also needed is the Python [[https://pypi.org/project/semver/][semver]] module. T
 
 For source code management, Casual Lib uses ~git~.
 
-Given a clone of this repository, ensure that the directory holding ~casual-avg.el~ is in your ~info-path~. Add the following lines to your Emacs initialization file.
-#+begin_src elisp :lexical no
-  (require 'casual-avy)
-  (keymap-global-set "M-g" #'casual-avy-tmenu)
-#+end_src
+Given a clone of this repository, ensure that the directory holding ~casual-lib.el~ is in your ~info-path~.
 
 * Branches
 For Casual Lib development, there are two git branches of note:

--- a/lisp/casual-lib.el
+++ b/lisp/casual-lib.el
@@ -1,4 +1,4 @@
-;;; casual-lib.el --- Library routines for Casual porcelains -*- lexical-binding: t; -*-
+;;; casual-lib.el --- Library routines for Casual user interfaces -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2024  Charles Choi
 
@@ -23,7 +23,7 @@
 
 ;;; Commentary:
 
-;; Library routines for Casual porcelains.
+;; Library routines for Casual user interfaces.
 
 ;;; Code:
 (require 'transient)
@@ -32,7 +32,7 @@
 (defcustom casual-lib-hide-navigation nil
   "If non-nil then hide navigation controls.
 
-If non-nil, customize Casual porcelains to hide navigation controls for
+If non-nil, customize Casual user interfaces to hide navigation controls for
 `transient-quit-all' (control-q) and `transient-quit-one' (control-g)."
   :type 'boolean
   :group 'casual)
@@ -40,7 +40,7 @@ If non-nil, customize Casual porcelains to hide navigation controls for
 (defun casual-lib-customize-casual-lib-hide-navigation ()
   "Customize `casual-lib-hide-navigation'.
 
-Customize Casual porcelains to hide navigation commands."
+Customize Casual user interfaces to hide navigation commands."
   (interactive)
   (customize-variable 'casual-lib-hide-navigation))
 
@@ -52,7 +52,7 @@ Customize Casual porcelains to hide navigation commands."
 (defun casual-lib-customize-casual-lib-use-unicode ()
   "Customize `casual-lib-use-unicode'.
 
-Customize Casual porcelains to use Unicode symbols in place of strings
+Customize Casual user interfaces to use Unicode symbols in place of strings
 when appropriate."
   (interactive)
   (customize-variable 'casual-lib-use-unicode))
@@ -149,7 +149,7 @@ V is either nil or non-nil."
 This Transient suffix invokes the customize interface for the
 variable `casual-lib-use-unicode'.
 
-Note that this variable affects all Casual porcelains."
+Note that this variable affects all Casual user interfaces."
   :key "u"
   :transient nil
   :description (lambda ()
@@ -165,7 +165,7 @@ Note that this variable affects all Casual porcelains."
 This Transient suffix invokes the customize interface for the
 variable `casual-lib-hide-navigation'.
 
-Note that this variable affects all Casual porcelains."
+Note that this variable affects all Casual user interfaces."
   :key "n"
   :transient nil
   :description (lambda ()


### PR DESCRIPTION
- Support `casualt-mock` macro to mock a function via `cl-letf`.
- Copy edit: replace "porcelain" with "user interface".
